### PR TITLE
chore: add components.json bundle manifest (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # repo-standards
 
-<!-- [![CI](https://github.com/<username>/repo-standards/actions/workflows/ci.yml/badge.svg)](https://github.com/<username>/repo-standards/actions/workflows/ci.yml) -->
-<!-- [![npm version](https://img.shields.io/npm/v/repo-standards.svg)](https://www.npmjs.com/package/repo-standards) -->
+[![CI](https://github.com/<username>/repo-standards/actions/workflows/ci.yml/badge.svg)](https://github.com/<username>/repo-standards/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/repo-standards.svg)](https://www.npmjs.com/package/repo-standards)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A Node.js CLI tool that installs repository documentation into an existing
@@ -29,12 +29,12 @@ _GIF coming soon._
 
 ## Tech Stack
 
-| | |
-|---|---|
-| Runtime | Node.js 24 |
-| Language | JavaScript (ESM) |
+|             |                                                    |
+| ----------- | -------------------------------------------------- |
+| Runtime     | Node.js 24                                         |
+| Language    | JavaScript (ESM)                                   |
 | CLI prompts | [inquirer](https://www.npmjs.com/package/inquirer) |
-| HTTP | Native `fetch` |
+| HTTP        | Native `fetch`                                     |
 
 ---
 
@@ -79,15 +79,15 @@ Commit this file — it records what was installed and at what version.
 
 ### Available Bundles
 
-| Bundle | Description |
-|---|---|
-| `github-templates` | Issue templates, PR templates, and default PR template |
-| `community-health` | CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG, CODEOWNERS |
-| `readme-templates` | README templates for app, library, CLI, and API project types |
-| `labels-script` | Shell script to create the standard GitHub label set via the GitHub CLI |
-| `git-standards` | Reference docs for branching, Conventional Commits, PR conventions, and semantic versioning |
-| `github-standards` | Reference docs for GitHub labels, issues, milestones, and PR sidebar usage |
-| `dev-standards` | Reference docs for environment variables, TDD, and software licenses |
+| Bundle             | Description                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| `github-templates` | Issue templates, PR templates, and default PR template                                      |
+| `community-health` | CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG, CODEOWNERS                              |
+| `readme-templates` | README templates for app, library, CLI, and API project types                               |
+| `labels-script`    | Shell script to create the standard GitHub label set via the GitHub CLI                     |
+| `git-standards`    | Reference docs for branching, Conventional Commits, PR conventions, and semantic versioning |
+| `github-standards` | Reference docs for GitHub labels, issues, milestones, and PR sidebar usage                  |
+| `dev-standards`    | Reference docs for environment variables, TDD, and software licenses                        |
 
 ### File Conflicts
 

--- a/components.json
+++ b/components.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.0.0",
+  "bundles": {
+    "github-templates": {
+      "description": "Issue templates, PR templates, and default PR template. Drop into any GitHub repository.",
+      "paths": [
+        ".github/ISSUE_TEMPLATE",
+        ".github/PULL_REQUEST_TEMPLATE",
+        ".github/pull_request_template.md"
+      ]
+    },
+    "community-health": {
+      "description": "Standard community health files — CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG, CODEOWNERS. Essential for public and open source repositories.",
+      "paths": [
+        "community/CONTRIBUTING.md",
+        "community/CODE_OF_CONDUCT.md",
+        "community/SECURITY.md",
+        "community/CHANGELOG.md",
+        "community/CODEOWNERS"
+      ]
+    },
+    "readme-templates": {
+      "description": "README templates for four common project types — app, library, CLI, and API. Copy and rename the appropriate template to README.md.",
+      "paths": [
+        "community/README-app.md",
+        "community/README-library.md",
+        "community/README-cli.md",
+        "community/README-api.md"
+      ]
+    },
+    "labels-script": {
+      "description": "Shell script that creates the standard GitHub label set via the GitHub CLI. Run once after creating a new repository. Requires gh CLI.",
+      "paths": ["community/create-labels.sh"]
+    },
+    "git-standards": {
+      "description": "Reference docs for branching strategy, Conventional Commits, PR conventions, and semantic versioning. Pairs well with github-templates.",
+      "paths": [
+        "docs/git-standards/branching-strategy.md",
+        "docs/git-standards/conventional-commits.md",
+        "docs/git-standards/pr-conventions.md",
+        "docs/git-standards/semantic-versioning.md"
+      ]
+    },
+    "github-standards": {
+      "description": "Reference docs for GitHub labels, issues, milestones, and PR sidebar usage. Pairs well with github-templates and labels-script.",
+      "paths": [
+        "docs/github-standards/github-labels.md",
+        "docs/github-standards/github-issues.md",
+        "docs/github-standards/github-milestones.md",
+        "docs/github-standards/github-pr-sidebar.md"
+      ]
+    },
+    "dev-standards": {
+      "description": "Reference docs for environment variables, TDD, and software licenses.",
+      "paths": [
+        "docs/dev-standards/environment-variables.md",
+        "docs/dev-standards/tdd-reference.md",
+        "docs/dev-standards/software-licenses.md"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds the components.json bundle manifest that defines the available documentation bundles for repo-standards.

## Related Issues/Milestones

- Closes #12
- Milestone: Milestone 0 — Project Setup

## Changes

- Added components.json with seven bundles: github-templates, community-health, readme-templates, labels-script, git-standards, github-standards, dev-standards
- Excluded github-workflows bundle — installs CI config files, out of scope for this tool
- Excluded gas-typescript bundle — out of scope
- version set to 1.0.0

## Testing

- [x] CI passes
- [ ] Smoke check(s):
  - [ ] App builds
  - [ ] Basic flows unaffected

## Risk

- Risk level: Low
- Notes: Data file only — no executable code

## Checklist

- [x] Lint/format pass
- [x] No user-facing behavior changes (unless stated)
- [ ] Docs updated if needed