### PR TITLE
feat: implement file writer (#18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "inquirer": "^13.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "vitest",
+    "test": "vitest run",
     "coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "prepare": "husky"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 importers:
   .:
+    dependencies:
+      inquirer:
+        specifier: ^13.4.2
+        version: 13.4.2(@types/node@25.5.0)
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.0
@@ -331,6 +335,188 @@ packages:
         integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
       }
     engines: { node: '>=18.18' }
+
+  '@inquirer/ansi@2.0.5':
+    resolution:
+      {
+        integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+
+  '@inquirer/checkbox@5.1.4':
+    resolution:
+      {
+        integrity: sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.12':
+    resolution:
+      {
+        integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution:
+      {
+        integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.1':
+    resolution:
+      {
+        integrity: sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.13':
+    resolution:
+      {
+        integrity: sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution:
+      {
+        integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution:
+      {
+        integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+
+  '@inquirer/input@5.0.12':
+    resolution:
+      {
+        integrity: sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.12':
+    resolution:
+      {
+        integrity: sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.12':
+    resolution:
+      {
+        integrity: sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.2':
+    resolution:
+      {
+        integrity: sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.8':
+    resolution:
+      {
+        integrity: sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.8':
+    resolution:
+      {
+        integrity: sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.4':
+    resolution:
+      {
+        integrity: sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution:
+      {
+        integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution:
@@ -928,6 +1114,12 @@ packages:
       }
     engines: { node: '>=18' }
 
+  chardet@2.1.1:
+    resolution:
+      {
+        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
+      }
+
   cli-cursor@5.0.0:
     resolution:
       {
@@ -941,6 +1133,13 @@ packages:
         integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
       }
     engines: { node: '>=20' }
+
+  cli-width@4.1.0:
+    resolution:
+      {
+        integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==,
+      }
+    engines: { node: '>= 12' }
 
   cliui@8.0.1:
     resolution:
@@ -1273,10 +1472,28 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
+  fast-string-truncated-width@3.0.3:
+    resolution:
+      {
+        integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
+      }
+
+  fast-string-width@3.0.2:
+    resolution:
+      {
+        integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
+      }
+
   fast-uri@3.1.0:
     resolution:
       {
         integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+      }
+
+  fast-wrap-ansi@0.2.0:
+    resolution:
+      {
+        integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==,
       }
 
   fdir@6.5.0:
@@ -1396,6 +1613,13 @@ packages:
     engines: { node: '>=18' }
     hasBin: true
 
+  iconv-lite@0.7.2:
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: '>=0.10.0' }
+
   ignore@5.3.2:
     resolution:
       {
@@ -1429,6 +1653,18 @@ packages:
         integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==,
       }
     engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
+
+  inquirer@13.4.2:
+    resolution:
+      {
+        integrity: sha512-ziXEKBO6nxsX9Z3XEh7LNiUvYN/o5PYuYK+27l69NpjSUOh6JXQsQAKEw2AnZq5xvHeb3ZwkpzOxvNOswIX1fg==,
+      }
+    engines: { node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0' }
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   is-arrayish@0.2.1:
     resolution:
@@ -1807,6 +2043,13 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
+  mute-stream@3.0.0:
+    resolution:
+      {
+        integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
+
   nanoid@3.3.11:
     resolution:
       {
@@ -1993,6 +2236,25 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
+
+  run-async@4.0.6:
+    resolution:
+      {
+        integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==,
+      }
+    engines: { node: '>=0.12.0' }
+
+  rxjs@7.8.2:
+    resolution:
+      {
+        integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
+      }
+
+  safer-buffer@2.1.2:
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   semver@7.7.4:
     resolution:
@@ -2546,6 +2808,125 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.4(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/confirm@6.0.12(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/core@11.1.9(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/editor@5.1.1(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/external-editor': 3.0.0(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/expand@5.0.13(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/external-editor@3.0.0(@types/node@25.5.0)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.12(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/number@4.0.12(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/password@5.0.12(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/prompts@8.4.2(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.4(@types/node@25.5.0)
+      '@inquirer/confirm': 6.0.12(@types/node@25.5.0)
+      '@inquirer/editor': 5.1.1(@types/node@25.5.0)
+      '@inquirer/expand': 5.0.13(@types/node@25.5.0)
+      '@inquirer/input': 5.0.12(@types/node@25.5.0)
+      '@inquirer/number': 4.0.12(@types/node@25.5.0)
+      '@inquirer/password': 5.0.12(@types/node@25.5.0)
+      '@inquirer/rawlist': 5.2.8(@types/node@25.5.0)
+      '@inquirer/search': 4.1.8(@types/node@25.5.0)
+      '@inquirer/select': 5.1.4(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/rawlist@5.2.8(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/search@4.1.8(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/select@5.1.4(@types/node@25.5.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+    optionalDependencies:
+      '@types/node': 25.5.0
+
+  '@inquirer/type@4.0.5(@types/node@25.5.0)':
+    optionalDependencies:
+      '@types/node': 25.5.0
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -2824,6 +3205,8 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chardet@2.1.1: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -2832,6 +3215,8 @@ snapshots:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.0
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3030,7 +3415,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3087,6 +3482,10 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -3099,6 +3498,18 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   ini@4.1.1: {}
+
+  inquirer@13.4.2(@types/node@25.5.0):
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.9(@types/node@25.5.0)
+      '@inquirer/prompts': 8.4.2(@types/node@25.5.0)
+      '@inquirer/type': 4.0.5(@types/node@25.5.0)
+      mute-stream: 3.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 25.5.0
 
   is-arrayish@0.2.1: {}
 
@@ -3281,6 +3692,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -3381,6 +3794,14 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
 
+  run-async@4.0.6: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
 
   shebang-command@2.0.0:
@@ -3453,8 +3874,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/writer.js
+++ b/src/writer.js
@@ -8,7 +8,7 @@
  */
 
 import { mkdir, writeFile as fsWriteFile, access } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, resolve, sep } from 'node:path'
 
 import inquirer from 'inquirer'
 
@@ -41,7 +41,14 @@ const fileExists = async absPath => {
  * @returns {Promise<void>}
  */
 export const writeFile = async ({ path: filePath, content }) => {
-  const absPath = join(process.cwd(), filePath)
+  const cwd = process.cwd()
+  const absPath = resolve(cwd, filePath)
+
+  // Guard against path traversal — absolute paths and .. segments both escape cwd via resolve
+  if (!absPath.startsWith(cwd + sep)) {
+    throw new Error(`Refusing to write outside project root: ${filePath}`)
+  }
+
   const dir = dirname(absPath)
 
   // recursive: true silently no-ops if the directory already exists

--- a/src/writer.js
+++ b/src/writer.js
@@ -1,0 +1,66 @@
+/**
+ * File Writer
+ *
+ * @module
+ * @description Writes fetched files into the consumer project directory.
+ * Creates missing parent directories, and prompts on conflict rather than
+ * overwriting silently.
+ */
+
+import { mkdir, writeFile as fsWriteFile, access } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import inquirer from 'inquirer'
+
+/**
+ * Check whether a file exists at the given absolute path
+ *
+ * @param {string} absPath - Absolute path to check
+ * @returns {Promise<boolean>} True if the file exists
+ * @private
+ */
+const fileExists = async absPath => {
+  try {
+    await access(absPath)
+    return true
+  } catch {
+    // access throws if the file does not exist — no dedicated exists check in fs/promises
+    return false
+  }
+}
+
+/**
+ * Write a single file into the consumer project directory
+ *
+ * Creates parent directories as needed. If the file already exists, prompts
+ * the user to overwrite or skip. New files are written without prompting.
+ *
+ * @param {{path: string, content: string}} file - Resolved file path and content
+ * @param {string} file.path - File path relative to the repository root
+ * @param {string} file.content - Decoded file content
+ * @returns {Promise<void>}
+ */
+export const writeFile = async ({ path: filePath, content }) => {
+  const absPath = join(process.cwd(), filePath)
+  const dir = dirname(absPath)
+
+  // recursive: true silently no-ops if the directory already exists
+  await mkdir(dir, { recursive: true })
+
+  const exists = await fileExists(absPath)
+
+  if (exists) {
+    const { overwrite } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'overwrite',
+        message: `${filePath} already exists. Overwrite?`,
+        default: false, // safe default — overwrite is destructive
+      },
+    ])
+
+    if (!overwrite) return
+  }
+
+  await fsWriteFile(absPath, content, 'utf-8')
+}

--- a/tests/writer.test.js
+++ b/tests/writer.test.js
@@ -1,0 +1,172 @@
+/**
+ * File Writer Tests
+ *
+ * @module
+ * @description Unit tests for the file writer module.
+ * Covers directory creation, file writing, existence checks, and overwrite prompting.
+ */
+
+import { mkdir, writeFile as fsWriteFile, access } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import inquirer from 'inquirer'
+
+import { writeFile } from '../src/writer.js'
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  access: vi.fn(),
+}))
+
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}))
+
+// ============================================================================
+// FIXTURES
+// ============================================================================
+
+const mockFile = {
+  path: 'docs/contributing.md',
+  content: '# Contributing',
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Simulate a file that does not exist
+ *
+ * @returns {void}
+ */
+// access throws on a missing file — rejection mirrors real fs behavior
+const mockFileNotExists = () => access.mockRejectedValueOnce(new Error('ENOENT'))
+
+/**
+ * Simulate a file that already exists
+ *
+ * @returns {void}
+ */
+const mockFileExists = () => access.mockResolvedValueOnce(undefined)
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+beforeEach(() => {
+  vi.spyOn(process, 'cwd').mockReturnValue('/mock/project')
+  // resetAllMocks in afterEach clears these — re-apply defaults each test
+  mkdir.mockResolvedValue(undefined)
+  fsWriteFile.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetAllMocks()
+})
+
+/**
+ * @description Tests for the writeFile function
+ */
+describe('writeFile', () => {
+  /**
+   * @test
+   * @description Confirms parent directories are created before writing
+   */
+  it('creates parent directories before writing', async () => {
+    // Arrange
+    mockFileNotExists()
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(mkdir).toHaveBeenCalledWith(join('/mock/project', 'docs'), { recursive: true })
+  })
+
+  /**
+   * @test
+   * @description Confirms the file is written at the correct path relative to cwd
+   */
+  it('writes the file at the correct path relative to cwd', async () => {
+    // Arrange
+    mockFileNotExists()
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(fsWriteFile).toHaveBeenCalledWith(
+      join('/mock/project', 'docs/contributing.md'),
+      '# Contributing',
+      'utf-8'
+    )
+  })
+
+  /**
+   * @test
+   * @description Confirms new files are written without prompting the user
+   */
+  it('writes new files without prompting', async () => {
+    // Arrange
+    mockFileNotExists()
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(inquirer.prompt).not.toHaveBeenCalled()
+  })
+
+  /**
+   * @test
+   * @description Confirms the user is prompted before an existing file is overwritten
+   */
+  it('prompts before overwriting an existing file', async () => {
+    // Arrange
+    mockFileExists()
+    inquirer.prompt.mockResolvedValueOnce({ overwrite: false })
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(inquirer.prompt).toHaveBeenCalled()
+  })
+
+  /**
+   * @test
+   * @description Confirms the file is written when the user confirms the overwrite
+   */
+  it('overwrites the file when the user confirms', async () => {
+    // Arrange
+    mockFileExists()
+    inquirer.prompt.mockResolvedValueOnce({ overwrite: true })
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(fsWriteFile).toHaveBeenCalled()
+  })
+
+  /**
+   * @test
+   * @description Confirms the file is skipped when the user declines to overwrite
+   */
+  it('skips writing when the user declines to overwrite', async () => {
+    // Arrange
+    mockFileExists()
+    inquirer.prompt.mockResolvedValueOnce({ overwrite: false })
+
+    // Act
+    await writeFile(mockFile)
+
+    // Assert
+    expect(fsWriteFile).not.toHaveBeenCalled()
+  })
+})

--- a/tests/writer.test.js
+++ b/tests/writer.test.js
@@ -169,4 +169,16 @@ describe('writeFile', () => {
     // Assert
     expect(fsWriteFile).not.toHaveBeenCalled()
   })
+
+  /**
+   * @test
+   * @description Confirms paths that escape the project root are rejected
+   */
+  it('throws when path resolves outside the project root', async () => {
+    // Arrange — .. segments escape cwd after resolve normalizes them
+    const traversalFile = { path: '../../etc/passwd', content: 'x' }
+
+    // Act + Assert
+    await expect(writeFile(traversalFile)).rejects.toThrow('outside project root')
+  })
 })


### PR DESCRIPTION
## Description

Adds `src/writer.js` — the file writer module that materializes fetched files into the consumer project directory. Prompts on conflict rather than overwriting silently.

## Related Issues/Milestones

- Closes #18
- Closes #15 
- Milestone: Milestone 1 — Core Implementation

## Changes

- Add `src/writer.js` exporting `writeFile({ path, content })`
- Add `tests/writer.test.js` with 6 test cases (TDD)
- Install `inquirer` as a production dependency

## Motivation & Context

The file writer bridges the GitHub Contents API client and the consumer's filesystem. Safe conflict handling (prompt vs. silent overwrite) is a core design requirement per the architecture doc.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual validation steps (if applicable):
  1. Tests pass: `pnpm test` — 13/13

## Breaking Changes

None.

## Checklist

- [x] Follows project conventions (lint, format, naming)
- [x] JSDoc updated where applicable
- [ ] Docs updated (README/docs) if behavior changed
- [ ] CI green

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file fetching from GitHub repositories
  * Added file writing with overwrite confirmation prompts

* **Tests**
  * Added comprehensive test coverage for file operations

* **Chores**
  * Updated CI status badge
  * Improved test configuration and tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->