### PR TITLE
fix: encode URL path segments and handle large files in GitHub client (#28, #29)

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -15,7 +15,8 @@ import { BASE_URL } from './constants.js'
  * @returns {string} Full API URL
  * @private
  */
-const buildUrl = path => `${BASE_URL}/${path}`
+// encode each segment separately to preserve / as a path delimiter
+const buildUrl = path => `${BASE_URL}/${path.split('/').map(encodeURIComponent).join('/')}`
 
 /**
  * Build request headers
@@ -70,6 +71,11 @@ const fetchFromApi = async path => {
  */
 export const fetchFile = async path => {
   const response = await fetchFromApi(path)
+
+  // GitHub returns encoding: 'none' and empty content for files > 1MB
+  if (response.encoding === 'none' || !response.content) {
+    throw new Error(`File too large to fetch inline: ${path}`)
+  }
 
   return {
     path: response.path,

--- a/tests/github.test.js
+++ b/tests/github.test.js
@@ -147,6 +147,39 @@ describe('fetchFile', () => {
       'docs/git-standards/branching-strategy.md'
     )
   })
+
+  /**
+   * @test
+   * @description Confirms path segments are URL-encoded in the request URL
+   */
+  it('encodes reserved characters in the request URL', async () => {
+    // Arrange
+    const encodedResponse = { ...mockFileResponse, path: 'docs/file with spaces.md' }
+    fetch.mockResolvedValueOnce(mockFetchResponse(encodedResponse))
+
+    // Act
+    await fetchFile('docs/file with spaces.md')
+
+    // Assert
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('file%20with%20spaces.md'),
+      expect.any(Object)
+    )
+  })
+
+  /**
+   * @test
+   * @description Confirms an error is thrown for files the API cannot return inline (>1MB)
+   */
+  it('throws for files the API cannot return inline', async () => {
+    // Arrange — GitHub returns encoding: 'none' and empty content for files > 1MB
+    fetch.mockResolvedValueOnce(
+      mockFetchResponse({ ...mockFileResponse, encoding: 'none', content: '' })
+    )
+
+    // Act + Assert
+    await expect(fetchFile('docs/git-standards/branching-strategy.md')).rejects.toThrow('too large')
+  })
 })
 
 /**


### PR DESCRIPTION
## Description

Two bugs in `src/github.js`: path segments were not URL-encoded, and files >1MB caused an opaque `Buffer.from(undefined)` crash.

## Related Issues/Milestones

- Fixes #28
- Fixes #29
- Milestone: Milestone 1 — Core Implementation

## Root Cause

`buildUrl` interpolated `path` directly — reserved characters produced malformed URLs. `fetchFile` passed `response.content` to `Buffer.from` without checking if the API returned `encoding: 'none'` (its signal for files it cannot inline).

## Changes

- `buildUrl`: encode each segment with `encodeURIComponent`, join with `/`
- `fetchFile`: throw a descriptive error when `encoding === 'none'` or `content` is empty

## Testing

- [ ] Reproduction steps confirmed on main
- [x] Added regression test(s)
- [x] Verified fix via:
  - [x] Unit tests
  - [ ] Integration tests
  - [ ] Manual steps

## Risk & Rollback

- Risk level: Low
- Rollback plan: revert commit on this branch

## Checklist

- [x] Lint/format pass
- [ ] CI green
- [ ] Affects docs? If yes, updated

## Screenshots/Logs (if applicable)

N/A