### PR TITLE
feat: implement setup.js CLI (#19)

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -1,0 +1,143 @@
+/**
+ * CLI Entry Point
+ *
+ * @module
+ * @description Orchestrates the repo-standards install flow: loads the bundle
+ * manifest, prompts the user to select bundles, fetches and writes selected
+ * files, and writes a .repo-standards lockfile on completion.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import inquirer from 'inquirer'
+
+import { fetchDirectory, fetchFile } from './github.js'
+import { writeFile as writeLocalFile } from './writer.js'
+
+/** @type {string} Sentinel value for the Select All checkbox option */
+export const SELECT_ALL = '__select_all__'
+
+/**
+ * Load and parse the components.json bundle manifest
+ *
+ * @returns {Promise<{version: string, bundles: object}>} Parsed manifest
+ */
+export const loadComponents = async () => {
+  // resolve relative to this file, not cwd — components.json ships with the package
+  const dir = dirname(fileURLToPath(import.meta.url))
+  const raw = await readFile(join(dir, '..', 'components.json'), 'utf-8')
+  return JSON.parse(raw)
+}
+
+/**
+ * Build inquirer checkbox choices from the bundle manifest
+ *
+ * @param {object} bundles - Bundles map from components.json
+ * @returns {Array<{name: string, value: string}>} Choices array with Select All first
+ */
+export const buildChoices = bundles => [
+  { name: 'Select All', value: SELECT_ALL },
+  ...Object.entries(bundles).map(([name, bundle]) => ({
+    name: `${name} — ${bundle.description}`,
+    value: name,
+  })),
+]
+
+/**
+ * Prompt the user to select bundles via an interactive checkbox
+ *
+ * @param {Array} choices - Inquirer choices array
+ * @param {object} bundles - Bundles map, used to expand Select All
+ * @returns {Promise<string[]>} Selected bundle names
+ * @private
+ */
+const promptBundles = async (choices, bundles) => {
+  const { selected } = await inquirer.prompt([
+    {
+      type: 'checkbox',
+      name: 'selected',
+      message: 'Select documentation bundles to install:',
+      choices,
+    },
+  ])
+
+  // Select All expands to every bundle name in the manifest
+  if (selected.includes(SELECT_ALL)) {
+    return Object.keys(bundles)
+  }
+
+  return selected
+}
+
+/**
+ * Fetch all files for a list of bundle paths
+ *
+ * Tries fetchDirectory first; falls back to fetchFile for plain file paths.
+ * The GitHub API returns an array for directories and an object for files —
+ * fetchDirectory throws when it receives an object with no .map method.
+ *
+ * @param {string[]} paths - File or directory paths from the bundle manifest
+ * @returns {Promise<Array<{path: string, content: string}>>} Flat list of resolved files
+ */
+export const fetchBundlePaths = async paths => {
+  const results = await Promise.all(
+    paths.map(async path => {
+      try {
+        return await fetchDirectory(path)
+      } catch {
+        return [await fetchFile(path)]
+      }
+    })
+  )
+  return results.flat()
+}
+
+/**
+ * Write the .repo-standards lockfile to the consumer project root
+ *
+ * @param {string} version - Bundle manifest version
+ * @param {string[]} bundleNames - Names of installed bundles
+ * @returns {Promise<void>}
+ */
+export const writeLockfile = async (version, bundleNames) => {
+  const lockfile = {
+    version,
+    installedBundles: bundleNames,
+    installedAt: new Date().toISOString(),
+  }
+  await writeFile(
+    join(process.cwd(), '.repo-standards'),
+    JSON.stringify(lockfile, null, 2),
+    'utf-8'
+  )
+}
+
+/**
+ * Run the repo-standards interactive install flow
+ *
+ * @returns {Promise<void>}
+ */
+export const run = async () => {
+  const { version, bundles } = await loadComponents()
+  const choices = buildChoices(bundles)
+  const selected = await promptBundles(choices, bundles)
+
+  if (selected.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('No bundles selected. Nothing installed.')
+    return
+  }
+
+  for (const name of selected) {
+    const files = await fetchBundlePaths(bundles[name].paths)
+    for (const file of files) {
+      await writeLocalFile(file)
+    }
+  }
+
+  await writeLockfile(version, selected)
+  // eslint-disable-next-line no-console
+  console.log(`Installed ${selected.length} bundle(s). Lockfile written to .repo-standards`)
+}

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -1,0 +1,309 @@
+/**
+ * CLI Setup Tests
+ *
+ * @module
+ * @description Unit tests for the CLI entry point.
+ * Covers component loading, bundle selection, file fetching, and lockfile writing.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import inquirer from 'inquirer'
+
+import { fetchFile, fetchDirectory } from '../src/github.js'
+import { writeFile as writeLocalFile } from '../src/writer.js'
+import {
+  run,
+  loadComponents,
+  buildChoices,
+  fetchBundlePaths,
+  writeLockfile,
+  SELECT_ALL,
+} from '../src/setup.js'
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}))
+
+vi.mock('../src/github.js', () => ({
+  fetchFile: vi.fn(),
+  fetchDirectory: vi.fn(),
+}))
+
+vi.mock('../src/writer.js', () => ({
+  writeFile: vi.fn(),
+}))
+
+const mockBundles = {
+  'git-standards': {
+    description: 'Git reference docs',
+    paths: ['docs/git-standards/branching-strategy.md'],
+  },
+  'github-templates': {
+    description: 'GitHub templates',
+    paths: ['.github/ISSUE_TEMPLATE', '.github/pull_request_template.md'],
+  },
+}
+
+const mockComponents = {
+  version: '1.0.0',
+  bundles: mockBundles,
+}
+
+const mockFile = {
+  path: 'docs/git-standards/branching-strategy.md',
+  content: '# Branching Strategy',
+}
+
+/**
+ * Mock a successful components.json load
+ *
+ * @returns {void}
+ */
+const mockComponentsLoad = () => readFile.mockResolvedValueOnce(JSON.stringify(mockComponents))
+
+beforeEach(() => {
+  vi.spyOn(process, 'cwd').mockReturnValue('/mock/project')
+  // resetAllMocks in afterEach clears these — re-apply defaults each test
+  writeFile.mockResolvedValue(undefined)
+  writeLocalFile.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetAllMocks()
+})
+
+/**
+ * @description Tests for the loadComponents function
+ */
+describe('loadComponents', () => {
+  /**
+   * @test
+   * @description Confirms components.json is read and parsed into version and bundles
+   */
+  it('returns parsed version and bundles from components.json', async () => {
+    // Arrange
+    readFile.mockResolvedValueOnce(JSON.stringify(mockComponents))
+
+    // Act
+    const result = await loadComponents()
+
+    // Assert
+    expect(result).toEqual(mockComponents)
+  })
+})
+
+/**
+ * @description Tests for the buildChoices function
+ */
+describe('buildChoices', () => {
+  /**
+   * @test
+   * @description Confirms Select All is the first choice in the list
+   */
+  it('includes Select All as the first choice', () => {
+    // Arrange + Act
+    const choices = buildChoices(mockBundles)
+
+    // Assert
+    expect(choices[0]).toMatchObject({ value: SELECT_ALL })
+  })
+
+  /**
+   * @test
+   * @description Confirms each bundle appears as a choice with its name and description
+   */
+  it('includes a choice for each bundle with name and description', () => {
+    // Arrange + Act
+    const choices = buildChoices(mockBundles)
+    const values = choices.map(c => c.value)
+    const names = choices.map(c => c.name)
+
+    // Assert
+    expect(values).toContain('git-standards')
+    expect(values).toContain('github-templates')
+    expect(names.some(n => n.includes('Git reference docs'))).toBe(true)
+    expect(names.some(n => n.includes('GitHub templates'))).toBe(true)
+  })
+})
+
+/**
+ * @description Tests for the fetchBundlePaths function
+ */
+describe('fetchBundlePaths', () => {
+  /**
+   * @test
+   * @description Confirms directory paths are resolved via fetchDirectory
+   */
+  it('resolves directory paths via fetchDirectory', async () => {
+    // Arrange
+    fetchDirectory.mockResolvedValueOnce([mockFile])
+
+    // Act
+    const result = await fetchBundlePaths(['.github/ISSUE_TEMPLATE'])
+
+    // Assert
+    expect(fetchDirectory).toHaveBeenCalledWith('.github/ISSUE_TEMPLATE')
+    expect(result).toEqual([mockFile])
+  })
+
+  /**
+   * @test
+   * @description Confirms plain file paths fall back to fetchFile when fetchDirectory throws
+   */
+  it('falls back to fetchFile when fetchDirectory throws', async () => {
+    // Arrange — fetchDirectory throws for plain files (response has no .map)
+    fetchDirectory.mockRejectedValueOnce(new Error('not a directory'))
+    fetchFile.mockResolvedValueOnce(mockFile)
+
+    // Act
+    const result = await fetchBundlePaths(['docs/git-standards/branching-strategy.md'])
+
+    // Assert
+    expect(fetchFile).toHaveBeenCalledWith('docs/git-standards/branching-strategy.md')
+    expect(result).toEqual([mockFile])
+  })
+
+  /**
+   * @test
+   * @description Confirms results across multiple paths are returned as a flat list
+   */
+  it('returns a flat list across multiple paths', async () => {
+    // Arrange
+    const fileA = { path: 'a.md', content: 'A' }
+    const fileB = { path: 'b.md', content: 'B' }
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockResolvedValueOnce(fileA)
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockResolvedValueOnce(fileB)
+
+    // Act
+    const result = await fetchBundlePaths(['a.md', 'b.md'])
+
+    // Assert
+    expect(result).toEqual([fileA, fileB])
+  })
+})
+
+/**
+ * @description Tests for the writeLockfile function
+ */
+describe('writeLockfile', () => {
+  /**
+   * @test
+   * @description Confirms lockfile is written at cwd with correct version, bundles, and date
+   */
+  it('writes .repo-standards at cwd with version, bundles, and date', async () => {
+    // Arrange
+    const bundles = ['git-standards']
+
+    // Act
+    await writeLockfile('1.0.0', bundles)
+
+    // Assert
+    expect(writeFile).toHaveBeenCalledWith(
+      join('/mock/project', '.repo-standards'),
+      expect.any(String),
+      'utf-8'
+    )
+    const written = JSON.parse(writeFile.mock.calls[0][1])
+    expect(written).toMatchObject({
+      version: '1.0.0',
+      installedBundles: ['git-standards'],
+      installedAt: expect.any(String),
+    })
+  })
+})
+
+/**
+ * @description Tests for the run function
+ */
+describe('run', () => {
+  /**
+   * @test
+   * @description Confirms nothing is fetched or written when no bundles are selected
+   */
+  it('does nothing when no bundles are selected', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: [] })
+
+    // Act
+    await run()
+
+    // Assert
+    expect(fetchDirectory).not.toHaveBeenCalled()
+    expect(fetchFile).not.toHaveBeenCalled()
+    expect(writeLocalFile).not.toHaveBeenCalled()
+  })
+
+  /**
+   * @test
+   * @description Confirms only selected bundles are fetched and written
+   */
+  it('fetches and writes only the selected bundles', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: ['git-standards'] })
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockResolvedValueOnce(mockFile)
+
+    // Act
+    await run()
+
+    // Assert
+    expect(fetchFile).toHaveBeenCalledWith('docs/git-standards/branching-strategy.md')
+    expect(writeLocalFile).toHaveBeenCalledWith(mockFile)
+    expect(fetchFile).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * @test
+   * @description Confirms the lockfile is written after all selected bundles are installed
+   */
+  it('writes the lockfile after installation completes', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: ['git-standards'] })
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockResolvedValueOnce(mockFile)
+
+    // Act
+    await run()
+
+    // Assert
+    expect(writeFile).toHaveBeenCalledWith(
+      join('/mock/project', '.repo-standards'),
+      expect.any(String),
+      'utf-8'
+    )
+  })
+
+  /**
+   * @test
+   * @description Confirms Select All installs every bundle in the manifest
+   */
+  it('installs every bundle when Select All is chosen', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: [SELECT_ALL] })
+    // all paths fall back to fetchFile — 3 total across both mock bundles
+    fetchDirectory.mockRejectedValue(new Error())
+    fetchFile.mockResolvedValue(mockFile)
+
+    // Act
+    await run()
+
+    // Assert — git-standards (1 path) + github-templates (2 paths) = 3 calls
+    expect(fetchFile).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -306,4 +306,37 @@ describe('run', () => {
     // Assert — git-standards (1 path) + github-templates (2 paths) = 3 calls
     expect(fetchFile).toHaveBeenCalledTimes(3)
   })
+
+  /**
+   * @test
+   * @description Confirms errors during fetch propagate and abort installation
+   */
+  it('propagates errors from fetchBundlePaths', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: ['git-standards'] })
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockRejectedValueOnce(new Error('API error'))
+
+    // Act + Assert
+    await expect(run()).rejects.toThrow('API error')
+  })
+
+  /**
+   * @test
+   * @description Confirms the lockfile is not written if installation fails mid-way
+   */
+  it('does not write the lockfile if installation fails', async () => {
+    // Arrange
+    mockComponentsLoad()
+    inquirer.prompt.mockResolvedValueOnce({ selected: ['git-standards'] })
+    fetchDirectory.mockRejectedValueOnce(new Error())
+    fetchFile.mockRejectedValueOnce(new Error('API error'))
+
+    // Act
+    await run().catch(() => {})
+
+    // Assert — lockfile must not be written if install did not complete
+    expect(writeFile).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Description

Adds `src/setup.js` — the CLI entry point that ties all modules together into the interactive `npx repo-standards` experience.

## Related Issues/Milestones

- #19
- #13 
- #14 
- Milestone: Milestone 1 — Core Implementation

## Changes

- Add `src/setup.js` exporting `run`, `loadComponents`, `buildChoices`, `fetchBundlePaths`, `writeLockfile`, and `SELECT_ALL`
- Add `tests/setup.test.js` with 11 test cases (TDD)

## Motivation & Context

`setup.js` is the user-facing layer. It orchestrates `github.js` (fetch), `writer.js` (write), and `inquirer` (prompt) behind a single interactive checkbox flow. The lockfile records what was installed for visibility in version history.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual validation steps (if applicable):
  1. Tests pass: `pnpm test` — 27/27

## Breaking Changes

None.

## Checklist

- [x] Follows project conventions (lint, format, naming)
- [x] JSDoc updated where applicable
- [ ] Docs updated (README/docs) if behavior changed
- [x] CI green

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive CLI tool for installing repo standards bundles with customizable selection options
  * Support for "Select All" functionality to install complete bundle sets at once
  * Automatic generation of installation lockfile to track version and bundle history

* **Tests**
  * Added comprehensive test suite for setup and installation workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->