### PR TITLE
chore: configure package for npx execution (#20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "repo-standards",
   "version": "0.1.0",
   "description": "A CLI tool that installs repository documentation into an existing project",
+  "bin": {
+    "repo-standards": "./src/setup.js"
+  },
   "type": "module",
   "engines": {
     "node": ">=22",

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * CLI Entry Point
  *


### PR DESCRIPTION
## Description

Adds `bin` field to `package.json` and `#!/usr/bin/env node` shebang to `setup.js` so the package executes via `npx repo-standards` without a global install.

Closes #20

## Related Issues/Milestones

- Closes #20
- Milestone: Milestone 2 — Release

## Changes

- `package.json` — adds `bin` field pointing to `./src/setup.js`
- `src/setup.js` — adds shebang as first line

## Checklist

- [x] `bin` field present in `package.json` referencing `setup.js`
- [x] Shebang present as first line of `setup.js`
- [x] Tests pass locally
- [x] CI green