### PR TITLE
chore: publish v1.0.0 to npm (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.0.0] - 2026-04-21
+
+### Added
+
+- Interactive CLI (`npx repo-standards`) — presents a checkbox of available documentation bundles fetched from the GitHub Contents API
+- `github-templates` bundle — issue templates, PR templates, default PR template
+- `community-health` bundle — CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG, CODEOWNERS
+- `readme-templates` bundle — README templates for app, library, CLI, and API projects
+- `labels-script` bundle — shell script to create standard GitHub label set via `gh` CLI
+- `git-standards` bundle — branching strategy, Conventional Commits, PR conventions, semantic versioning reference docs
+- `github-standards` bundle — GitHub labels, issues, milestones, PR sidebar reference docs
+- `dev-standards` bundle — TDD reference and software licenses reference docs
+- `.repo-standards` lockfile written on completion — records version, installed bundles, and install date
+- `GITHUB_TOKEN` environment variable support — raises API rate limit from 60 to 5,000 requests/hour
+- File conflict prompting — never overwrites silently

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-standards",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A CLI tool that installs repository documentation into an existing project",
   "bin": {
     "repo-standards": "./src/setup.js"


### PR DESCRIPTION
## Description

Bumps package version to 1.0.0, updates CHANGELOG with v1.0.0 release notes, and prepares the package for npm publish.

Closes #21

## Related Issues/Milestones

- Closes #21
- Milestone: Milestone 2 — Release

## Changes

- `package.json` — version bumped to 1.0.0
- `CHANGELOG.md` — v1.0.0 release notes added

## Checklist

- [x] `package.json` and `components.json` versions aligned at 1.0.0
- [x] CHANGELOG updated with v1.0.0 release notes
- [x] Git tag v1.0.0 created and pushed
- [x] GitHub release created
- [x] Package visible on npmjs.com as repo-standards
- [x] `npx repo-standards` resolves to the published package