### PR TITLE
fix: invoke run() when setup.js is executed as CLI entry point

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -146,5 +146,9 @@ export const run = async () => {
 }
 
 if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  run()
+  run().catch(err => {
+    // eslint-disable-next-line no-console
+    console.error(err.message)
+    process.exit(1)
+  })
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -10,6 +10,7 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises'
+import { realpathSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -142,4 +143,8 @@ export const run = async () => {
   await writeLockfile(version, selected)
   // eslint-disable-next-line no-console
   console.log(`Installed ${selected.length} bundle(s). Lockfile written to .repo-standards`)
+}
+
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run()
 }


### PR DESCRIPTION
## Description

`setup.js` exported `run()` but never called it, so running the CLI via `npx` or `node` did nothing. Adds an ESM-compatible entry point guard that invokes `run()` only when the file is executed directly (not imported as a module).

Uses `realpathSync` to resolve bin symlinks so the check works correctly when installed as an npm package and invoked via `npx`.

## Related Issues/Milestones

- Milestone: Milestone 2 — Release

## Changes

- `src/setup.js` — adds `realpathSync` import and entry point guard to invoke `run()`

## Checklist

- [x] CLI executes correctly via `node src/setup.js`
- [x] CLI executes correctly via `npx` after local install
- [x] Unit tests unaffected — guard prevents `run()` from firing on import
- [x] Tests pass locally
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup script to execute only when run directly as the main entry point, preventing unintended automatic invocation when imported as a module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->