### PR TITLE
chore: fix dev-standards description and add npm keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Commit this file — it records what was installed and at what version.
 | `labels-script`    | Shell script to create the standard GitHub label set via the GitHub CLI                     |
 | `git-standards`    | Reference docs for branching, Conventional Commits, PR conventions, and semantic versioning |
 | `github-standards` | Reference docs for GitHub labels, issues, milestones, and PR sidebar usage                  |
-| `dev-standards`    | Reference docs for environment variables, TDD, and software licenses                        |
+| `dev-standards`    | Reference docs for TDD and software licenses                                                |
 
 ### File Conflicts
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
     "e2e": "node tests/e2e.mjs",
     "prepare": "husky"
   },
+  "keywords": [
+    "cli",
+    "github",
+    "git",
+    "templates",
+    "standards",
+    "documentation"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",


### PR DESCRIPTION
## Description

Fixes stale `dev-standards` bundle description in README (still referenced environment variables after that doc was removed) and adds `keywords` to `package.json` for npm discoverability.

## Related Issues/Milestones

N/A

## Changes

- `README.md` — removes "environment variables" from `dev-standards` description
- `package.json` — adds keywords: `cli`, `github`, `git`, `templates`, `standards`, `documentation`

## Testing

- [x] CI passes
- [x] Smoke check(s):
  - [x] App builds
  - [x] Basic flows unaffected

## Risk

- Risk level: Low
- Notes: No behavior changes

## Checklist

- [x] Lint/format pass
- [x] No user-facing behavior changes (unless stated)
- [x] Docs updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bundle descriptions in README.

* **Chores**
  * Added keywords to package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->