### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.1] - 2026-04-21
+
+### Fixed
+
+- Stale `dev-standards` bundle description in README (removed environment variables reference)
+
+### Changed
+
+- Added npm keywords for discoverability
+
+---
+
 ## [1.0.0] - 2026-04-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-standards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A CLI tool that installs repository documentation into an existing project",
   "bin": {
     "repo-standards": "./src/setup.js"


### PR DESCRIPTION
## Description

Patch release bumping version to 1.0.1 following README and keyword fixes in #40.

## Related Issues/Milestones

N/A

## Changes

- `package.json` — version bumped to 1.0.1
- `CHANGELOG.md` — 1.0.1 release notes added

## Testing

- [x] CI passes
- [x] Smoke check(s):
  - [x] App builds
  - [x] Basic flows unaffected

## Risk

- Risk level: Low
- Notes: Version bump only

## Checklist

- [x] Lint/format pass
- [x] No user-facing behavior changes (unless stated)
- [x] Docs updated if needed