### PR TITLE
docs: add retrospective artifacts for v1.0.1

### DIFF
--- a/docs/2026-04-20-github-api-bugs.md
+++ b/docs/2026-04-20-github-api-bugs.md
@@ -1,0 +1,60 @@
+# Postmortem — GitHub API bugs shipped in initial implementation
+
+**Date:** 2026-04-20
+**Severity:** P3
+**Status:** Complete
+**Author(s):** Solo
+
+---
+
+## Summary
+
+Two bugs in `src/github.js` merged to `main` as part of the initial implementation (`#17`) and required a dedicated fix PR (`#30`) after the fact. Bug 1: path segments were not URL-encoded, causing requests for paths containing special characters to fail. Bug 2: files larger than 1MB returned by the API with `encoding: 'none'` were not detected, causing a `Buffer.from` call on empty content rather than a clear error.
+
+---
+
+## Timeline
+
+| Time  | Event                                                                                                                         |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Day 1 | `#17` implemented and merged — GitHub Contents API client                                                                     |
+| Day 2 | Integration testing exposed URL encoding failure on paths with spaces/special characters                                      |
+| Day 2 | Large file edge case identified — API returns `encoding: 'none'` and empty `content` for files >1MB; code did not handle this |
+| Day 2 | Issues `#28` and `#29` opened                                                                                                 |
+| Day 2 | `#30` opened, reviewed, and merged — both bugs fixed together                                                                 |
+
+---
+
+## Root Cause
+
+Unit tests for `#17` mocked `fetch` with controlled responses that never exercised real API behavior. URL encoding and large file handling are edge cases that only surface against the actual GitHub Contents API. The test surface did not extend to these conditions.
+
+---
+
+## Contributing Factors
+
+- No integration or e2e test existed at the time of `#17` — the e2e test was added later in `#34`
+- Acceptance criteria for `#17` did not include testing against real API paths containing special characters or large files
+
+---
+
+## Impact
+
+- Both bugs were caught before any consumer use of the tool
+- No published version was affected
+- Required an unplanned fix PR, adding scope to Milestone 1
+
+---
+
+## Action Items
+
+| Action                                                                        | Owner            | Due                                  |
+| ----------------------------------------------------------------------------- | ---------------- | ------------------------------------ |
+| Add e2e test covering real API calls before merging any GitHub client changes | @scottgilmoredev | Ongoing — `tests/e2e.mjs` now exists |
+| Include real-path smoke test in acceptance criteria for API client issues     | @scottgilmoredev | Before next API client change        |
+
+---
+
+## Lessons Learned
+
+Mocked unit tests verify logic, not integration. Any module that wraps an external API needs at least one test path that exercises the real API before merge — or explicit acceptance criteria that surface edge cases the mock cannot reach.

--- a/docs/2026-04-21-entry-point-not-invoked.md
+++ b/docs/2026-04-21-entry-point-not-invoked.md
@@ -1,0 +1,64 @@
+# Postmortem — CLI entry point not invoked
+
+**Date:** 2026-04-21
+**Severity:** P3
+**Status:** Complete
+**Author(s):** Solo
+
+---
+
+## Summary
+
+`src/setup.js` was implemented, tested, and merged in `#19` without ever calling `run()`. The file exported all functions correctly and all unit tests passed, but executing the file as a CLI did nothing. The bug was caught during manual local testing after `npm pack` and before `npm publish`. Fixed in `#39`.
+
+---
+
+## Timeline
+
+| Time  | Event                                                                                  |
+| ----- | -------------------------------------------------------------------------------------- |
+| Day 1 | `#19` implemented and merged — `setup.js` CLI orchestrator                             |
+| Day 2 | `#20` merged — `bin` field and shebang added to configure npx execution                |
+| Day 2 | `#21` merged — version bumped to 1.0.0, CHANGELOG updated                              |
+| Day 2 | `git tag v1.0.0` created and pushed                                                    |
+| Day 2 | Local `npm pack` + install — running `node src/setup.js` produced no output            |
+| Day 2 | Root cause identified: `run()` exported but never called                               |
+| Day 2 | `#39` opened and merged — entry point guard added, `run()` invoked on direct execution |
+| Day 2 | `npm publish` run — published package includes the fix                                 |
+
+---
+
+## Root Cause
+
+The acceptance criteria for `#19` covered the behavior of exported functions (`loadComponents`, `buildChoices`, `fetchBundlePaths`, `writeLockfile`, `run`) but not the executable behavior of the file itself. Unit tests import `setup.js` as a module — they never ask "does running this file do anything?" The gap between module behavior and CLI behavior was not part of the test strategy or definition of done.
+
+---
+
+## Contributing Factors
+
+- No e2e test existed at the time `#19` merged — the e2e test was added in `#34`, after this gap was already present
+- The `#20` issue (bin field + shebang) was treated as infrastructure — it configured how the file would be invoked but did not verify that invocation produced the expected behavior
+- No pre-publish checklist existed to require a manual smoke test before tagging
+
+---
+
+## Impact
+
+- The bug was caught before `npm publish` ran — no consumer was affected
+- The git tag `v1.0.0` points to a commit without the fix; the published `v1.0.0` package includes it (publish used HEAD, not the tag)
+- Required an unplanned fix PR during the release phase
+
+---
+
+## Action Items
+
+| Action                                                                             | Owner            | Due                   |
+| ---------------------------------------------------------------------------------- | ---------------- | --------------------- |
+| Add "running the file produces expected behavior" to CLI issue acceptance criteria | @scottgilmoredev | Before next CLI issue |
+| Add pre-publish manual smoke test to release checklist                             | @scottgilmoredev | Before next release   |
+
+---
+
+## Lessons Learned
+
+A CLI that exports functions correctly and passes all unit tests can still do nothing when executed. Executable behavior must be verified as a distinct step — separate from module behavior. For any CLI issue, the definition of done is not complete until someone has run the file and seen the expected output.

--- a/docs/aar.md
+++ b/docs/aar.md
@@ -1,0 +1,124 @@
+# After Action Review — repo-standards v1.0.1
+
+**Date:** 2026-04-21
+**Scope:** Full project — from initial setup through v1.0.1 npm publish
+**Participants:** Solo
+
+---
+
+## What Was Planned
+
+Three milestones defined upfront in `docs/development-plan.md`:
+
+**Milestone 0 — Project Setup**
+Repository configuration, local development environment, CI workflow, planning documentation, and community health files. Project ready for implementation before a line of feature code was written.
+
+**Milestone 1 — Core Implementation**
+Four implementation issues, each developed via TDD:
+
+- `#17` — GitHub Contents API client (`src/github.js`)
+- `#18` — File writer (`src/writer.js`)
+- `#19` — CLI orchestrator (`src/setup.js`)
+- `#12` — `components.json` bundle manifest
+
+All bundles fetchable and installable end-to-end on completion.
+
+**Milestone 2 — Release**
+
+- `#20` — `bin` field and shebang for `npx` execution
+- `#21` — Publish to npm as `repo-standards@1.0.0`
+
+---
+
+## What Actually Happened
+
+Milestone 0 delivered as planned.
+
+Milestone 1 largely delivered, but with significant divergence:
+
+- **GitHub API bugs surfaced post-merge** — URL encoding (`#28`) and large file handling (`#29`) were not caught during the original implementation of `#17`. Required a dedicated fix PR after `#17` had already merged.
+- **Bundle content files were untracked scope** — `components.json` was authored (`#12`) but the actual files it referenced were never tracked as implementation work. The gap was identified before e2e testing, not by it. Required opening `#32` mid-milestone.
+- **`environment-variables.md` removed from scope** — identified during bundle content review as too stack-specific. Removed from `components.json` and deleted.
+- **e2e smoke test added** — not planned. Added in `#34` to validate the full install flow against the real GitHub API and filesystem.
+
+Milestone 2 delivered with one notable pre-publish fix and one post-publish cleanup:
+
+- **Entry point not invoked** — `setup.js` exported `run()` but never called it. Found during manual local testing before `npm publish` ran. The git tag `v1.0.0` preceded the fix; the published package included it. Fixed in `#39`.
+- **Patch release 1.0.1** — stale `README.md` content and missing npm keywords addressed post-publish. Required a second publish cycle (`#40`, `#41`).
+
+---
+
+## Why the Difference
+
+**GitHub API bugs not caught in original implementation**
+The unit tests for `#17` used mocked `fetch` responses and did not exercise real API behavior. URL encoding and large file edge cases were outside the mock surface. The bugs were latent until real API calls were made during integration testing.
+
+**Bundle content files were invisible scope**
+The development plan described the CLI fetching bundles from the repo, but the work of populating those paths was never translated into a tracked issue. `components.json` was treated as complete once the manifest schema was defined — without verifying that the referenced paths existed. A missing acceptance criterion ("all paths in `components.json` resolve successfully") would have caught this before `#19` closed.
+
+**Entry point not invoked**
+The acceptance criteria for `#19` covered the exported functions but not the executable behavior of the file. Unit tests import `setup.js` as a module — they never exercise it as a CLI entry point. The gap between module behavior and executable behavior was not part of the test strategy or definition of done.
+
+**`environment-variables.md` scope drift**
+The dev-standards bundle was defined early without evaluating each doc against the tool's intended consumer. The file contained framework-specific content incompatible with a generic tool. The evaluation should have happened at bundle-definition time, not after the files were committed.
+
+**README stale post-publish**
+The README was not audited against `components.json` before publishing. No pre-publish checklist existed to catch this kind of drift.
+
+---
+
+## Sustains
+
+**TDD discipline held throughout**
+Every feature was built RED → GREEN → REFACTOR. Tests were written before implementation on every issue. The test suite caught regressions when bugs were fixed in `#28`/`#29` and remained stable through all subsequent changes.
+
+**Small, focused PRs**
+No PR tried to do too much. Each addressed a single issue. CodeRabbit review feedback was actionable, and the focused PR structure made it easy to isolate bugs and review changes.
+
+**CodeRabbit caught real issues**
+Automated review surfaced shell script hardening (`set -euo pipefail`, `gh` availability check), stale Obsidian wiki link artifacts in docs, and unhandled promise rejection on the entry point guard — all legitimate issues that warranted fixing.
+
+**e2e testing validated what unit tests could not**
+The smoke test in `tests/e2e.mjs` hit the real GitHub API, wrote to a real temp directory, and validated the full install flow end-to-end. Unit tests, however comprehensive, cannot substitute for this.
+
+**`.github/` files serve dual purpose without duplication**
+The project's own issue and PR templates are the same files installable via the `github-templates` bundle. One set of files, two purposes — no maintenance burden.
+
+---
+
+## Improvements
+
+**Bundle content must be tracked scope from the start**
+Any path in `components.json` that does not exist in the repo at the time of authoring is unfinished work. Acceptance criteria for the bundle manifest issue should include: all referenced paths exist and resolve successfully. This should be a checklist item on the PR.
+
+**Entry point behavior belongs in acceptance criteria**
+For any CLI issue, "executing the file runs the intended behavior" is an acceptance criterion, not an assumption. The `#19` issue and PR should have included a manual smoke test step: "running `node src/setup.js` presents the bundle selection prompt." An e2e test or explicit manual check should be part of the definition of done.
+
+**Define a pre-publish checklist**
+Before any publish, verify:
+
+- `README.md` accurately reflects `components.json`
+- `npm pack` + local install + manual run completes successfully
+- Unit tests green
+- e2e green
+
+**Evaluate bundle content at definition time**
+Each file added to a bundle should be evaluated for generic applicability when the bundle is first defined. A simple question — "would this file be useful to any project regardless of stack?" — would have flagged `environment-variables.md` before it was written and committed.
+
+**Community files duplication is a known tradeoff**
+The root-level community files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, etc.) and the installable templates in `community/` are maintained separately. This is intentional — the installable versions are generic, the project-level versions are specific — but it creates a maintenance surface. Any change to the generic template requires a conscious decision about whether the project-level version should also change. Worth documenting as an explicit convention rather than leaving implicit.
+
+**Conflict UX is a known gap**
+Issue `#38` (bulk conflict resolution) was opened after observing the experience of installing all bundles into a repo that already had most files — 30+ individual prompts. The current per-file behavior is technically correct but practically unusable at scale. Should be addressed before the tool is promoted for active use.
+
+---
+
+## Actions
+
+| Action                                                                | Owner            | By When                              |
+| --------------------------------------------------------------------- | ---------------- | ------------------------------------ |
+| Add "all bundle paths resolve" to bundle manifest acceptance criteria | @scottgilmoredev | Next bundle change                   |
+| Add entry point execution to CLI issue acceptance criteria            | @scottgilmoredev | Before next CLI issue                |
+| Document pre-publish checklist                                        | @scottgilmoredev | Before next release                  |
+| Implement bulk conflict resolution (`#38`)                            | @scottgilmoredev | Before promoting tool for active use |
+| Document community files duplication as an explicit convention        | @scottgilmoredev | Next `CONTRIBUTING.md` update        |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,96 @@
+# Decision Log — repo-standards
+
+---
+
+## Use realpathSync to resolve bin symlink in entry point guard — 2026-04-21
+
+**Decision:** Use `realpathSync(process.argv[1])` rather than `process.argv[1]` directly when comparing against `fileURLToPath(import.meta.url)` to determine if `setup.js` is the CLI entry point.
+
+**Context:** The initial entry point guard (`process.argv[1] === fileURLToPath(import.meta.url)`) worked when running the file directly with `node` but silently failed when invoked via `npx`. npm installs a symlink in `node_modules/.bin/` pointing to the actual file. `process.argv[1]` resolves to the symlink path, not the real file path, causing the comparison to fail and `run()` to never be called.
+
+**Alternatives considered:**
+
+- Check if `process.argv[1]` ends with `setup.js` — fragile, breaks if the file is renamed or nested differently
+- Call `run()` unconditionally — fires on import, disrupts unit tests unless mocked precisely at load time
+- Use `import.meta.main` — not available in Node.js (Deno only)
+
+**Rationale:** `realpathSync` resolves symlinks before comparison, making the check reliable regardless of how the file is invoked. One import, no fragility.
+
+**Consequences:** Requires importing `realpathSync` from `node:fs`. The guard is reliable across direct execution, `npx`, and local `npm install` scenarios.
+
+**Status:** Decided
+
+---
+
+## Remove environment-variables.md from dev-standards bundle — 2026-04-21
+
+**Decision:** Remove `docs/dev-standards/environment-variables.md` from the `dev-standards` bundle and delete the file.
+
+**Context:** During bundle content review, the file was found to contain Next.js and Vite scaffold references — framework-specific content incompatible with a tool intended to serve any project regardless of stack.
+
+**Alternatives considered:**
+
+- Genericize the file — stripping the framework-specific sections would leave a doc too thin to be worth installing
+
+**Rationale:** The test for inclusion is "would this file be useful to any project regardless of stack?" The file failed that test. Cutting it is cleaner than shipping a stripped-down version with diminishing value.
+
+**Consequences:** `dev-standards` bundle now contains only `tdd-reference.md` and `software-licenses.md`. The `environment-variables.md` file no longer exists in the repository.
+
+**Status:** Decided
+
+---
+
+## Load components.json relative to module file, not process.cwd() — 2026-04-21
+
+**Decision:** In `loadComponents()`, resolve the path to `components.json` using `dirname(fileURLToPath(import.meta.url))` rather than `process.cwd()`.
+
+**Context:** `components.json` ships with the npm package — it is a package artifact, not a project file. When a consumer runs `npx repo-standards` in their project directory, `process.cwd()` points to their project root, not the installed package. The manifest would not be found.
+
+**Alternatives considered:**
+
+- Pass the path as a parameter — adds unnecessary complexity to the public API; `loadComponents` has no reason to accept an external path
+- Use `__dirname` — not available in ESM modules
+
+**Rationale:** `import.meta.url` gives the URL of the current module file. Resolving relative to it ensures `components.json` is always found alongside `setup.js`, regardless of where the consumer runs the tool.
+
+**Consequences:** `components.json` must always be distributed at the package root (one level up from `src/`). This is enforced by the `files` field in `package.json` if one is added, or implicitly by the default npm publish behavior.
+
+**Status:** Decided
+
+---
+
+## Use fetchDirectory with fetchFile fallback for path resolution — 2026-04-21
+
+**Decision:** In `fetchBundlePaths()`, attempt `fetchDirectory()` first for every path; catch the error and fall back to `fetchFile()` rather than detecting path type upfront.
+
+**Context:** Bundle paths in `components.json` can be either files (`community/create-labels.sh`) or directories (`.github/ISSUE_TEMPLATE`). The GitHub Contents API returns an array for directories and an object for files. `fetchDirectory()` calls `.map()` on the response — if the response is an object (a file), it throws because objects don't have `.map`.
+
+**Alternatives considered:**
+
+- Inspect the path string for a file extension — fragile; extensionless files and directories with dots in their names would be misclassified
+- Add a `type` field to each bundle path in `components.json` — adds authoring overhead and a new convention to maintain for every future bundle path
+- Make a HEAD request first to determine type — an extra API call per path with no other benefit
+
+**Rationale:** The try/catch approach exploits a predictable API behavior (directory response is array, file response is object) without any upfront type information. Zero extra API calls, zero additional schema.
+
+**Consequences:** `fetchDirectory()` will be called even for known file paths, incurring one failed API call per file path. At bundle install scale this is negligible. The pattern is unintuitive without context — documented in the function's JSDoc.
+
+**Status:** Decided
+
+---
+
+## Bundle-level selection only — no file-level granularity — 2026-04-21
+
+**Decision:** The CLI presents bundles as the atomic unit of selection. Users choose which bundles to install; all files within a selected bundle are installed.
+
+**Context:** During implementation of `setup.js`, the question arose of whether users should be able to select individual files within a bundle rather than the entire bundle.
+
+**Alternatives considered:**
+
+- File-level selection — presents every file as a checkbox option; gives maximum flexibility but creates a long, overwhelming prompt for large bundles and requires users to understand the file structure before installing
+
+**Rationale:** Bundles are curated sets of related files that work together. Installing half a bundle (e.g., PR templates without the issue templates) produces an inconsistent result. The bundle is the meaningful unit of installation. Users who want a subset can install the bundle and delete what they don't need.
+
+**Consequences:** No mechanism exists to install a single file from a bundle. This is a deliberate constraint, not a gap. Issue `#38` (bulk conflict resolution) should be addressed before this decision is revisited.
+
+**Status:** Decided


### PR DESCRIPTION
## Description

Adds post-project retrospective documentation: after action review, decision log, and two postmortems.

## Related Issues/Milestones

N/A

## Changes

- `docs/aar.md` — after action review covering full project arc through v1.0.1
- `docs/decisions.md` — decision log for implementation decisions made during development
- `docs/2026-04-20-github-api-bugs.md` — postmortem for GitHub API bugs shipped in initial implementation
- `docs/2026-04-21-entry-point-not-invoked.md` — postmortem for CLI entry point not invoked

## Checklist

- [x] CI green
- [x] No production code changed